### PR TITLE
zabbix(agent): Update zabbix agent role

### DIFF
--- a/collections/my/homelab/roles/zabbix/defaults/main.yml
+++ b/collections/my/homelab/roles/zabbix/defaults/main.yml
@@ -6,7 +6,7 @@ zabbix_agent_release_channel: "release"
 ## Connection
 zabbix_agent_server_addr: null
 zabbix_agent_server_port: 10051
-zabbix_agent_listen_ip: "0.0.0.0"
+zabbix_agent_listen_ip: "auto"
 
 ## Identity and metadata
 zabbix_agent_hostname: "{{ inventory_hostname }}"

--- a/collections/my/homelab/roles/zabbix/templates/zabbix_agent2.conf.j2
+++ b/collections/my/homelab/roles/zabbix/templates/zabbix_agent2.conf.j2
@@ -3,7 +3,11 @@
 Hostname={{ zabbix_agent_hostname }}
 Server={{ zabbix_agent_server_addr }}
 ServerActive={{ zabbix_agent_server_addr }}:{{ zabbix_agent_server_port }}
-ListenIP={{ zabbix_agent_listen_ip }}
+ListenIP={% if zabbix_agent_listen_ip == 'auto' %}
+{{ ansible_default_ipv4.address }}
+{% else %}
+{{ zabbix_agent_listen_ip }}
+{% endif %}
 ListenPort={{ zabbix_agent_listen_port }}
 HostMetadata={{ zabbix_metadata }}
 


### PR DESCRIPTION
Set agent listen IP var to 'auto' by default

Update template to use the primary IP if set to 'auto'